### PR TITLE
fix for BlockFilter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,9 @@ function constructFilter(filterName, query) {
             try {
               changeResult.forEach((log, logIndex) => {
                 decodedChangeResults[logIndex] = changeResult[logIndex];
-                decodedChangeResults[logIndex].data = self.options.decoder(decodedChangeResults[logIndex].data);
+                if (typeof changeResult[logIndex] === 'object') {
+                  decodedChangeResults[logIndex].data = self.options.decoder(decodedChangeResults[logIndex].data);
+                }
               });
             } catch (decodingErrorMesage) {
               decodingError = new Error(`[ethjs-filter] while decoding filter change event data from RPC '${JSON.stringify(decodedChangeResults)}': ${decodingErrorMesage}`);


### PR DESCRIPTION
The BlockFilter example from the README is broken:

```
const filter = new filters.BlockFilter()

filter.watch((result) => {
  // result [{...}, ...] (fires multiple times)
});
```

With the PR, this works:
```
const filter = new filters.BlockFilter()
filter.new()
filter.watch((result) => {
  // result [{...}, ...] (fires multiple times)
});
```

